### PR TITLE
FreeBSD_12.1_build_fix_and_config_updates

### DIFF
--- a/projects/sgconv/sgconv.conf
+++ b/projects/sgconv/sgconv.conf
@@ -124,6 +124,6 @@ Store module
     # Database port
     # Parameter: optional
     # Value: any, supported by database
-    # Default: 0
+    # Default: 3306
     # Port = 3306
 #</DestStoreModule>

--- a/projects/sgconv/sgconv.conf
+++ b/projects/sgconv/sgconv.conf
@@ -125,5 +125,5 @@ Store module
     # Parameter: optional
     # Value: any, supported by database
     # Default: 0
-    # Port = 0
+    # Port = 3306
 #</DestStoreModule>

--- a/projects/sgconv/sgconv.conf
+++ b/projects/sgconv/sgconv.conf
@@ -121,4 +121,9 @@ Store module
     # Default: 123456
     # Password = 123456
 
+    # Database port
+    # Parameter: optional
+    # Value: any, supported by database
+    # Default: 0
+    # Port = 0
 #</DestStoreModule>

--- a/projects/stargazer/inst/freebsd/etc/stargazer/conf-available.d/store_mysql.conf
+++ b/projects/stargazer/inst/freebsd/etc/stargazer/conf-available.d/store_mysql.conf
@@ -28,5 +28,5 @@
     # Parameter: optional
     # Value: any, supported by database
     # Default: 0
-    Port = 0
+    Port = 3306
 </StoreModule>

--- a/projects/stargazer/inst/freebsd/etc/stargazer/conf-available.d/store_mysql.conf
+++ b/projects/stargazer/inst/freebsd/etc/stargazer/conf-available.d/store_mysql.conf
@@ -27,6 +27,6 @@
     # Database port
     # Parameter: optional
     # Value: any, supported by database
-    # Default: 0
-    Port = 3306
+    # Default: 3306
+    # Port = 3306
 </StoreModule>

--- a/projects/stargazer/inst/freebsd/etc/stargazer/conf-available.d/store_mysql.conf
+++ b/projects/stargazer/inst/freebsd/etc/stargazer/conf-available.d/store_mysql.conf
@@ -23,4 +23,10 @@
     # Value: any, supported by database
     # Default: 123456
     Password = 123456
+
+    # Database port
+    # Parameter: optional
+    # Value: any, supported by database
+    # Default: 0
+    Port = 0
 </StoreModule>

--- a/projects/stargazer/inst/linux/etc/stargazer/conf-available.d/store_mysql.conf
+++ b/projects/stargazer/inst/linux/etc/stargazer/conf-available.d/store_mysql.conf
@@ -28,5 +28,5 @@
     # Parameter: optional
     # Value: any, supported by database
     # Default: 0
-    Port = 0
+    Port = 3306
 </StoreModule>

--- a/projects/stargazer/inst/linux/etc/stargazer/conf-available.d/store_mysql.conf
+++ b/projects/stargazer/inst/linux/etc/stargazer/conf-available.d/store_mysql.conf
@@ -27,6 +27,6 @@
     # Database port
     # Parameter: optional
     # Value: any, supported by database
-    # Default: 0
-    Port = 3306
+    # Default: 3306
+    # Port = 3306
 </StoreModule>

--- a/projects/stargazer/inst/linux/etc/stargazer/conf-available.d/store_mysql.conf
+++ b/projects/stargazer/inst/linux/etc/stargazer/conf-available.d/store_mysql.conf
@@ -23,4 +23,10 @@
     # Value: any, supported by database
     # Default: 123456
     Password = 123456
+
+    # Database port
+    # Parameter: optional
+    # Value: any, supported by database
+    # Default: 0
+    Port = 0
 </StoreModule>

--- a/projects/stargazer/scripts/shaper_vpn_radius/stargazer/stargazer.conf
+++ b/projects/stargazer/scripts/shaper_vpn_radius/stargazer/stargazer.conf
@@ -186,6 +186,9 @@ ModulesPath = /usr/lib/stg
 #
 #    # Адрес сервера БД
 #    dbhost = localhost
+
+#    # Порт сервера БД
+#    dbport = 3306
 #</StoreModule>
 
 

--- a/stglibs/pinger.lib/include/stg/pinger.h
+++ b/stglibs/pinger.lib/include/stg/pinger.h
@@ -18,7 +18,7 @@
 #include <netinet/ip_icmp.h>
 #endif
 
-#if defined (__FreeBSD__) && (__FreeBSD__ >= 5)
+#if defined (FREE_BSD5)
 #include <sys/types.h>
 #endif
 

--- a/stglibs/pinger.lib/include/stg/pinger.h
+++ b/stglibs/pinger.lib/include/stg/pinger.h
@@ -19,6 +19,7 @@
 #endif
 
 #if defined (FREE_BSD) || defined (FREE_BSD5) || defined(DARWIN)
+#include <sys/types.h>
 #include <netinet/in.h>
 #include <netinet/in_systm.h>
 #include <netinet/ip.h>

--- a/stglibs/pinger.lib/include/stg/pinger.h
+++ b/stglibs/pinger.lib/include/stg/pinger.h
@@ -18,8 +18,11 @@
 #include <netinet/ip_icmp.h>
 #endif
 
-#if defined (FREE_BSD) || defined (FREE_BSD5) || defined(DARWIN)
+#if defined (__FreeBSD__) && (__FreeBSD__ >= 5)
 #include <sys/types.h>
+#endif
+
+#if defined (FREE_BSD) || defined (FREE_BSD5) || defined(DARWIN)
 #include <netinet/in.h>
 #include <netinet/in_systm.h>
 #include <netinet/ip.h>


### PR DESCRIPTION
Added fix to prevent build crash under FreeBSD 12.1. Tested on clean FreeBSD 12.1 releases:
    FreeBSD 12.1-RELEASE FreeBSD 12.1-RELEASE
    FreeBSD 12.1-RELEASE-p13 FreeBSD 12.1-RELEASE-p13 GENERIC  amd64
    
Added 'port' option to configs